### PR TITLE
xonotic: download from mesa ci master

### DIFF
--- a/sixonix/xonotic/conf.json
+++ b/sixonix/xonotic/conf.json
@@ -4,7 +4,7 @@
         "executable" : "Xonotic/xonotic.exe"
     },
     "linux" : {
-        "package" : "http://dl.xonotic.org/xonotic-0.8.2.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/xonotic-0.8.2.zip",
         "executable" : [
             "Xonotic/xonotic-linux-glx.sh",
             "Xonotic/xonotic-linux64-glx"


### PR DESCRIPTION
Downloading xonotic from the external xonotic server is very
unreliable in CI, so this changes the location to a locally cached
version of the xonotic archive.