### PR TITLE
benchmarks: download from mesa ci perf master

### DIFF
--- a/sixonix/gfxbench4/conf.json
+++ b/sixonix/gfxbench4/conf.json
@@ -1,10 +1,10 @@
 {
     "windows" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/windows/gfxbench_gl-vs2013-4.0.0-public_fixes+corporate.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/windows/gfxbench_gl-vs2013-4.0.0-public_fixes+corporate.zip",
         "executable" : "gfxbench_gl-vs2013-4.0.0+corporate/bin/testfw_app.exe"
     },
     "linux" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/gfxbench_gl-build-4.0.13-candidate+corporate.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/gfxbench_gl-build-4.0.13-candidate+corporate.zip",
         "executable" : "testfw_app"
     }
 }

--- a/sixonix/gfxbench5/conf.json
+++ b/sixonix/gfxbench5/conf.json
@@ -1,10 +1,10 @@
 {
     "windows" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/gfxbench_vulkan-vs2015-x64-5.0.0-GOLD2+corporate.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/gfxbench_vulkan-vs2015-x64-5.0.0-GOLD2+corporate.zip",
         "executable" : "gfxbench_vulkan-vs2015-x64-5.0.0-GOLD2+corporate/bin/testfw_app.exe"
     },
     "linux" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/gfxbench_vulkan-linux-x86_64-5.0.0-GOLD2+corporate.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/gfxbench_vulkan-linux-x86_64-5.0.0-GOLD2+corporate.zip",
         "executable" : "gfxbench_vulkan-linux-x86_64-5.0.0-GOLD2+corporate/bin/testfw_app"
     }
 }

--- a/sixonix/gputest/conf.json
+++ b/sixonix/gputest/conf.json
@@ -1,10 +1,10 @@
 {
     "windows" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/windows/GpuTest_Windows_x64_0.7.0.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/windows/GpuTest_Windows_x64_0.7.0.zip",
         "executable" : "GpuTest_Windows_x64_0.7.0/GpuTest.exe"
     },
     "linux" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/GpuTest_Linux_x64_0.7.0.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/GpuTest_Linux_x64_0.7.0.zip",
         "executable" : "GpuTest_Linux_x64_0.7.0/GpuTest"
     }
 }

--- a/sixonix/synmark/conf.json
+++ b/sixonix/synmark/conf.json
@@ -1,12 +1,12 @@
 {
     "windows" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/windows/Unigine.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/windows/Unigine.zip",
         "executable" : "Unigine/Sanctuary/Unigine.exe"
     },
     "linux" : {
         "package" : [
-            "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/Synmark2-7.0.0.zip",
-            "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/libjpeg8.zip"
+            "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/Synmark2-7.0.0.zip",
+            "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/libjpeg8.zip"
         ],
         "executable" : "Synmark2-7.0.0/synmark2"
     }

--- a/sixonix/unigine/conf.json
+++ b/sixonix/unigine/conf.json
@@ -1,11 +1,11 @@
 {
     "windows" : {
-        "package" : "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/windows/Unigine.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/windows/Unigine.zip",
         "executable" : "Unigine/Sanctuary/Unigine.exe"
     },
     "linux" : {
-        "package" : ["http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/Unigine_Heaven-4.0.run",
-                    "http://otc-mesa-ci.jf.intel.com/userContent/benchmarks/linux/Unigine_Valley-1.0.run"],
+        "package" : ["http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/Unigine_Heaven-4.0.run",
+                    "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/linux/Unigine_Valley-1.0.run"],
         "executable" : ["Unigine_Heaven-4.0/heaven",
                         "Unigine_Valley-1.0/bin/browser_x64"]
     }

--- a/sixonix/xonotic/conf.json
+++ b/sixonix/xonotic/conf.json
@@ -1,10 +1,10 @@
 {
     "windows" : {
-        "package" : "http://dl.xonotic.org/xonotic-0.8.2.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/xonotic-0.8.2.zip",
         "executable" : "Xonotic/xonotic.exe"
     },
     "linux" : {
-        "package" : "http://otc-mesa-android.jf.intel.com/userContent/xonotic-0.8.2.zip",
+        "package" : "http://otc-mesa-android.jf.intel.com/userContent/benchmarks/xonotic-0.8.2.zip",
         "executable" : [
             "Xonotic/xonotic-linux-glx.sh",
             "Xonotic/xonotic-linux64-glx"


### PR DESCRIPTION
This changes all benchmark sources to a local cache on the Mesa perf CI
master system. Grabbing them remotely or from a system on a different
Mesa CI network causes failures if network utilization is high.